### PR TITLE
リリース時のCHANGELOG出力を有効化

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,4 +64,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  skip: false


### PR DESCRIPTION
sacloudプロダクトの最近の運用方針に合わせる。

- PRはSquash Mergeする
- PRタイトルには短い日本語を用いる
- リリース時にGoReleaserでCHANGELOGを出力する
