### PR TITLE
go 1.20

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Describe plugin
         id: plugin_describe

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Setup tools
         run: |
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Setup tools
         run: | 
@@ -47,7 +47,8 @@ jobs:
       - name: make lint-go
         run:  |
           # Explicitly set GOROOT to avoid golangci-lint/issues/3107
-          export GOROOT=$(go env GOROOT)
+          GOROOT=$(go env GOROOT)
+          export GOROOT
           make lint-go
 
   test:
@@ -66,7 +67,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Setup tools
         run: | 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 AS builder
+FROM golang:1.20 AS builder
 MAINTAINER Usacloud Authors <sacloud.users@gmail.com>
 
 RUN set -x

--- a/go.mod
+++ b/go.mod
@@ -102,4 +102,4 @@ require (
 
 replace github.com/zclconf/go-cty => github.com/azr/go-cty v1.1.1-0.20200203143058-28fcda2fe0cc
 
-go 1.19
+go 1.20

--- a/includes/go/common.mk
+++ b/includes/go/common.mk
@@ -19,7 +19,7 @@ COPYRIGHT_YEAR          ?= 2022
 COPYRIGHT_FILES         ?= $$(find . -name "*.go" -print | grep -v "/vendor/")
 GO                      ?= go
 DEFAULT_GOALS           ?= fmt set-license go-licenses-check goimports lint test
-GOLANG_CI_LINT_VERSION  ?= v1.49.0
+GOLANG_CI_LINT_VERSION  ?= v1.51.2
 TEXTLINT_ACTION_VERSION ?= v0.0.3
 
 .DEFAULT_GOAL = default


### PR DESCRIPTION
Note: `go generate`がエラーになるが #134 で packer-sdcがv0.4.0になれば解消することを確認済み。
このためこのPRでは特にエラーへの対応は行わない。