### PR TITLE
Fix VNC address construction

### DIFF
--- a/sakuracloud/step_type_boot_command.go
+++ b/sakuracloud/step_type_boot_command.go
@@ -82,7 +82,7 @@ func (s *stepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 		host = vncCredentials.IOServerHost
 	}
 
-	nc, err := net.Dial("tcp", fmt.Sprintf("%s:%s", host, vncCredentials.Port))
+	nc, err := net.Dial("tcp", vncAddress(host, vncCredentials.Port.String()))
 	if err != nil {
 		err := fmt.Errorf("Error connecting to VNC: %s", err)
 		state.Put("error", err)
@@ -138,6 +138,10 @@ func (s *stepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag)
 }
 
 func (*stepTypeBootCommand) Cleanup(multistep.StateBag) {}
+
+func vncAddress(host, port string) string {
+	return net.JoinHostPort(host, port)
+}
 
 func vncSendString(c *vnc.ClientConn, original string, useUSKeyboard bool) {
 	// Scancodes reference: https://github.com/qemu/qemu/blob/master/ui/vnc_keysym.h
@@ -458,7 +462,7 @@ func vncSendString(c *vnc.ClientConn, original string, useUSKeyboard bool) {
 		if keyCode == 0 {
 			r, size := utf8.DecodeRuneInString(original)
 			original = original[size:]
-			keyCode = uint32(r)
+			keyCode = uint32(r) //nolint:gosec // utf8.DecodeRuneInString never returns a negative rune.
 			keyShift = unicode.IsUpper(r) || strings.ContainsRune(shiftedChars, r)
 
 			log.Printf("Sending char '%c', code %d, shift %v", r, keyCode, keyShift)

--- a/sakuracloud/step_type_boot_command_test.go
+++ b/sakuracloud/step_type_boot_command_test.go
@@ -1,0 +1,33 @@
+package sakuracloud
+
+import "testing"
+
+func TestVNCAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		port string
+		want string
+	}{
+		{
+			name: "IPv4",
+			host: "192.0.2.1",
+			port: "5900",
+			want: "192.0.2.1:5900",
+		},
+		{
+			name: "IPv6",
+			host: "2001:db8::1",
+			port: "5900",
+			want: "[2001:db8::1]:5900",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := vncAddress(tt.host, tt.port); got != tt.want {
+				t.Errorf("vncAddress(%q, %q) = %q, want %q", tt.host, tt.port, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- build VNC endpoint addresses with `net.JoinHostPort`
- convert the API's `StringNumber` port value before constructing the endpoint
- suppress the false-positive G115 finding and cover IPv4/IPv6 address formatting

## Validation
- `go test ./sakuracloud -run '^TestVNCAddress$' -count=1`
- `make lint-go`