### PR TITLE
chore: update golangci-lint to v2.12.2 and Go to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sacloud/packer-plugin-sakuracloud
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/hashicorp/hcl/v2 v2.24.0

--- a/includes/go/common.mk
+++ b/includes/go/common.mk
@@ -42,7 +42,7 @@ dev-tools:
 	$(GO) install github.com/client9/misspell/cmd/misspell@latest
 	$(GO) install github.com/google/go-licenses@v1.0.0
 	$(GO) install github.com/rhysd/actionlint/cmd/actionlint@latest
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANG_CI_LINT_VERSION)
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANG_CI_LINT_VERSION)
 
 .PHONY: goimports
 goimports: fmt

--- a/includes/go/common.mk
+++ b/includes/go/common.mk
@@ -19,7 +19,7 @@ COPYRIGHT_YEAR          ?= 2023
 COPYRIGHT_FILES         ?= $$(find . -name "*.go" -print | grep -v "/vendor/")
 GO                      ?= go
 DEFAULT_GOALS           ?= fmt set-license go-licenses-check goimports lint test
-GOLANG_CI_LINT_VERSION  ?= v2.5.0
+GOLANG_CI_LINT_VERSION  ?= v2.13.1
 TEXTLINT_ACTION_VERSION ?= v0.0.3
 
 .DEFAULT_GOAL = default


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #

### このPRはどういう変更を行いますか？

golang 1.27 がリリースされたので、golang 1.26 を go.mod に記載します。
golangci-lint も最新版にしないと golang 1.26 で動かないので修正します。

### ドキュメントの変更は必要ですか？
