### PR TITLE
Dockerfile 内での go インタープリターバージョンを 1.26 にします

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 MAINTAINER Usacloud Authors <sacloud.users@gmail.com>
 
 RUN set -x


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #

### このPRはどういう変更を行いますか？

https://github.com/sacloud/packer-plugin-sakuracloud/commit/95d34185160618cd48d12558cb77086900469a8f で go.mod が 1.26 になったので、コンテナのベースイメージも 1.26 にしないといけなかったです。

### ドキュメントの変更は必要ですか？
