### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,7 @@
 name: Tests
 on: [push, pull_request]
+permissions:
+  contents: read
 env:
   GOPROXY: https://proxy.golang.org
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/sacloud/packer-plugin-sakuracloud/security/code-scanning/8](https://github.com/sacloud/packer-plugin-sakuracloud/security/code-scanning/8)

Add an explicit top-level `permissions` block in `.github/workflows/tests.yaml` so all jobs inherit minimal required privileges.  
Best fix without changing functionality: set:

- `contents: read`

This is sufficient for `actions/checkout` and read-only CI tasks. Place it at workflow root (after `on:` is a clear location), so it applies uniformly to `lint-text`, `lint-go`, and `test` without duplicating per-job settings.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
