### PR TITLE
Harden test workflow permissions

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '30 23 * * *'
   workflow_dispatch:
+permissions:
+  contents: read
 env:
   GOPROXY: https://proxy.golang.org
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,7 @@
 name: Tests
 on: [push, pull_request]
+permissions:
+  contents: read
 env:
   GOPROXY: https://proxy.golang.org
 jobs:


### PR DESCRIPTION
Explicitly grant the daily integration and test workflows only read access to repository contents. This prevents them from inheriting broader repository permissions while preserving checkout and test execution.